### PR TITLE
@mzikherman: Add ow:config and ow:config:from_env tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,18 +22,34 @@ And then execute:
     $ bundle exec rake momentum:init
 
 
-## Usage
+## Rake Tasks
 
-This gem adds a few useful rake tasks to your project:
+This gem adds a few useful rake tasks to your project. In general, the `aws_id` and `aws_secret` arguments are taken from `AWS_ID` and `AWS_SECRET` ENV variables. The `to` argument can refer to an environment or developer (e.g., _joey_ in the case of _reflection-joey_, or _staging_ in the case of _gravity-staging_). It's assumed that this value can be appended to the `app_base_name` to form the stack name.
 
-    bundle exec rake momentum:init  # Initialize a default librarian-chef config
-    bundle exec rake ow:cookbooks:update[to,aws_id,aws_secret]  # Zip, upload, and propagate custom cookbooks to the given stack
+### momentum:init
 
-In general, the `aws_id` and `aws_secret` arguments are taken from `AWS_ID` and `AWS_SECRET` ENV variables. So this command can be invoked like:
+Initialize a default librarian-chef config.
+
+### ow:config[to,aws_id,aws_secret]
+
+Print the custom configuration values for the given stack. E.g.:
+
+    bundle exec rake ow:config[joey]
+
+### ow:config:from_env[to,aws_id,aws_secret]
+
+Add the given stack's custom configuration values to the current task's ENV. Can be prepended to other rake tasks that depend on the ENV, e.g.:
+
+    bundle exec rake ow:config:from_env[production] some:migration
+
+### ow:cookbooks:update[to,aws_id,aws_secret]
+
+Zip, upload, and propagate custom cookbooks to the given stack. Or, more concisely:
 
     bundle exec rake ow:cookbooks:update[staging]
     # or just:
     bundle exec rake ow:cookbooks:update:staging
+
 
 ## Configuration:
 

--- a/lib/momentum/railtie.rb
+++ b/lib/momentum/railtie.rb
@@ -4,6 +4,7 @@ class Momentum::Railtie < ::Rails::Railtie
 
   rake_tasks do
     load 'tasks/init.rake'
+    load 'tasks/ow-config.rake'
     load 'tasks/ow-cookbooks.rake'
   end
 

--- a/lib/tasks/ow-config.rake
+++ b/lib/tasks/ow-config.rake
@@ -1,0 +1,24 @@
+namespace :ow do
+
+  desc "Print current configuration values for given stack."
+  task :config, [:to, :aws_id, :aws_secret] do |t, args|
+    require_credentials!(args)
+    ow = Momentum::OpsWorks.client(args[:aws_id], args[:aws_secret])
+    Momentum::OpsWorks::Config.from_stack(ow, stack_name(args[:to])).each do |k, v|
+      puts "#{k}: #{v}"
+    end
+  end
+
+  namespace :config do
+    desc "Set configuration values from OpsWorks on the current environment. Can be chained to other tasks that need the ENV."
+    task :from_env, [:to, :aws_id, :aws_secret] do |t, args|
+      require_credentials!(args)
+      ow = Momentum::OpsWorks.client(args[:aws_id], args[:aws_secret])
+      Momentum::OpsWorks::Config.from_stack(ow, stack_name(args[:to])).each do |k, v|
+        ENV[k] = v.to_s
+      end
+      @ow_config_from_env = true  # allow chained tasks to raise an error unless this is set
+    end
+  end
+
+end


### PR DESCRIPTION
This adds our common config-related tasks to the momentum gem:

Print config values for the appname-staging stack:

```
rake ow:config[staging]
```

Load the stack's custom config into the chained task's environment:

```
rake ow:config:from_env[staging] some:task
```
