### PR TITLE
@starsirius: Run librarian:config and librarian:init as part of momentum init

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ In your application's Rakefile, add this line above the `load_tasks` command:
 And then execute:
 
     $ bundle
+    $ gem install librarian-chef  # ideally this would be in the bundle, but has conflicts
     $ bundle exec rake momentum:init
 
 

--- a/lib/momentum/railtie.rb
+++ b/lib/momentum/railtie.rb
@@ -4,6 +4,7 @@ class Momentum::Railtie < ::Rails::Railtie
 
   rake_tasks do
     load 'tasks/init.rake'
+    load 'tasks/librarian.rake'
     load 'tasks/ow-config.rake'
     load 'tasks/ow-console.rake'
     load 'tasks/ow-cookbooks.rake'

--- a/lib/tasks/init.rake
+++ b/lib/tasks/init.rake
@@ -1,17 +1,6 @@
 namespace :momentum do
 
-  LIBRARIAN_CONFIG = <<-EOF
----
-LIBRARIAN_CHEF_PATH: #{Momentum.config[:cookbooks_install_path]}
-LIBRARIAN_CHEF_INSTALL__STRIP_DOT_GIT: '1'
-  EOF
-
   desc "Initialize a project with librarian-chef, etc."
-  task :init do
-    FileUtils.mkdir_p './.librarian/chef'
-    File.open('./.librarian/chef/config', 'w+') do |f|
-      f.write(LIBRARIAN_CONFIG)
-    end
-    $stderr.puts "Wrote .librarian/chef/config"
-  end
+  task :init => ['librarian:config', 'librarian:init']
+
 end

--- a/lib/tasks/librarian.rake
+++ b/lib/tasks/librarian.rake
@@ -1,0 +1,28 @@
+namespace :librarian do
+
+  LIBRARIAN_CONFIG = <<-EOF
+---
+LIBRARIAN_CHEF_PATH: #{Momentum.config[:cookbooks_install_path]}
+LIBRARIAN_CHEF_INSTALL__STRIP_DOT_GIT: '1'
+  EOF
+
+  task :config do
+    FileUtils.mkdir_p './.librarian/chef'
+    File.open('./.librarian/chef/config', 'w+') do |f|
+      f.write(LIBRARIAN_CONFIG)
+    end
+    $stderr.puts "Wrote .librarian/chef/config"
+  end
+
+  task :init => :require do
+    # librarian-chef and rails declare incompatible json dependencies,
+    # so librarian-chef must be installed but can't be in the bundle
+    Bundler.with_clean_env do
+      system "librarian-chef init"
+    end
+  end
+
+  task :require do
+    raise "librarian-chef must be installed!" if `which librarian-chef`.empty?
+  end
+end


### PR DESCRIPTION
This makes the `momentum:init` rake task a little more useful. Now it creates the correct .librarian/chef/config file and runs `librarian-chef init` to create an empty Cheffile.

Also, I discovered the `Bundler.with_clean_env` method, which removes all of the ENV/PATH-wrapping that Bundler normally does and lets you invoke non-bundled gems. Useful!
