### PR TITLE
@dylanfareed: Revise ow:logs task to accept a specific instance and fully qualified log path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+0.0.6 (2014-01-31)
+-----
+
+* Add `ow:logs[to,instance,log_path]` task - [@ibussieres](https://github.com/ibussieres)

--- a/README.md
+++ b/README.md
@@ -73,15 +73,13 @@ Trigger an OpsWorks deploy to the given stack. By default, deploys app to all ru
     # or just:
     bundle exec rake ow:deploy:staging
 
-### ow:logs[to,log_type,aws_id,aws_secret]
+### ow:logs[to,instance,log_path,aws_id,aws_secret]
 
 Execute a tail -f (follow) command against an error or access log file on the given remote OpsWorks stack. Default log is 'ssl-error'. Chooses an instance of the _rails-app_ layer. E.g.:
 
-    bundle exec rake ow:logs[staging,access]
-    # or error log
-    bundle exec rake ow:logs[staging,error]
-    # with ssl logs
-    bundle exec rake ow:logs[staging,ssl-error]
+    bundle exec rake ow:logs[staging,rails-app1,/srv/www/myapp/shared/log/staging.log]
+
+The log path may include wildcards.
 
 ## Configuration:
 
@@ -90,14 +88,13 @@ Execute a tail -f (follow) command against an error or access log file on the gi
 * **cookbooks_install_path** - Local path where librarian-chef will install cookbooks. Default: _tmp/cookbooks_
 * **custom_cookbooks_bucket** - Bucket to which custom cookbooks are uploaded. Default: _artsy-cookbooks_
 * **rails_console_layer** - The OpsWorks layer used for SSH-ing and starting a rails console. Default: _rails-app_
-* **logs_root** - The root directory for apache or nginx access and error logs. Default: _/var/log/apache2/_
 
 
 ## To Do
 
 * git/branch helpers
 * Integrate librarian-chef as legit dependency once rails/chef conflicts resolved
-* Add nginx/unicorn support to rake command for log files
+* Tests
 
 
 &copy; 2014 [Artsy](http://artsy.net). See [LICENSE](LICENSE.txt) for details.

--- a/lib/tasks/ow-logs.rake
+++ b/lib/tasks/ow-logs.rake
@@ -4,18 +4,17 @@ namespace :ow do
   require 'momentum/tasks'
 
   desc "Open a web server log tail on the given remote OpsWorks stack (uses AWS_USER as SSH username)."
-  task :logs, [:to, :log_type, :aws_id, :aws_secret] do |t, args|
+  task :logs, [:to, :instance, :log_path, :aws_id, :aws_secret] do |t, args|
     require_credentials!(args)
     ow = Momentum::OpsWorks.client(args[:aws_id], args[:aws_secret])
     name = stack_name(args[:to])
     stack = Momentum::OpsWorks.get_stack(ow, name)
-    layer = ow.describe_layers(stack_id: stack[:stack_id])[:layers].detect { |l| l[:shortname] == 'rails-app' }
-    instance = Momentum::OpsWorks.get_online_instances(ow, layer_id: layer[:layer_id]).sample
+    instance = Momentum::OpsWorks.get_online_instances(ow, stack_id: stack[:stack_id]).detect{|i| i[:hostname] == args[:instance] }
     endpoint = Momentum::OpsWorks.get_instance_endpoint(instance)
-    raise "No online rails-app instances found for #{name} stack!" unless endpoint
+    raise "Online instance #{args[:instance]} not found for #{name} stack!" unless endpoint
 
     $stderr.puts "Starting tail -f remotely... (use Ctrl-D to exit cleanly)"
-    command = "'sudo su deploy -c \"tail -f #{Momentum.config[:logs_root]}#{Momentum.config[:app_base_name]}-#{args[:log_type] || 'ssl-error'}.log\"'"
+    command = "'sudo su deploy -c \"tail -f #{args[:log_path]}\"'"
     sh Momentum::OpsWorks.ssh_command_to(endpoint,command)
   end
 


### PR DESCRIPTION
@ibussieres helpfully added an `ow:logs` task to tail logs (https://github.com/artsy/momentum/pull/6).

That was apache/passenger-specific, so I tweaked the interface to accept a specific instance name (rather than layer, from which a random instance was selected), and a fully qualified log path (rather than make assumptions about paths or extensions).

This allows commands such as:

```
bundle exec rake ow:logs[production,worker1,/srv/www/gravity/shared/log/delayed_job.log]
```

Or even:

```
bundle exec rake ow:logs[production,rails-app3,/srv/www/gravity/shared/log/*.log]
```

If it gets tiresome to type long file paths, we can always create wrapping tasks that specify the commonly tailed logs for us.
