### PR TITLE
@anyone: Add ow:ssh task for SSH-ing to remote instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.0.8 (...)
+-----
+
+* Add `ow:ssh` task - [@joeyAghion](https://github.com/joeyAghion)
+
 0.0.7 (2014-01-31)
 -----
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,15 @@ Execute a tail -f (follow) command against an error or access log file on the gi
 
 The log path may include wildcards.
 
+### ow:ssh[to,layer_or_instance,aws_id,aws_secret]
+
+SSH to an OpsWorks instance. If the `layer_or_instance` argument is a layer, an online instance is chosen randomly from the layer. Otherwise, the name of an online instance is expected. E.g.:
+
+    bundle exec rake ow:ssh[staging,memcached]
+    # or...
+    bundle exec rake ow:ssh[staging,rails-app1]
+
+
 ## Configuration:
 
 * **app_base_name** - Your app's name. Stacks are assumed to be named like _appbasename-env_ (e.g., _gravity-staging_ or _reflection-joey_).

--- a/lib/momentum/opsworks.rb
+++ b/lib/momentum/opsworks.rb
@@ -33,7 +33,7 @@ module Momentum::OpsWorks
     client.describe_instances(query)[:instances].select { |i| i[:status] == 'online' }
   end
 
-  def self.ssh_command_to(endpoint, command)
+  def self.ssh_command_to(endpoint, command = nil)
       [ 'ssh -t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no',
         (['-i', ENV['AWS_PUBLICKEY']] if ENV['AWS_PUBLICKEY']),
         (['-l', ENV['AWS_USER']] if ENV['AWS_USER']),

--- a/lib/momentum/railtie.rb
+++ b/lib/momentum/railtie.rb
@@ -10,6 +10,7 @@ class Momentum::Railtie < ::Rails::Railtie
     load 'tasks/ow-cookbooks.rake'
     load 'tasks/ow-deploy.rake'
     load 'tasks/ow-logs.rake'
+    load 'tasks/ow-ssh.rake'
   end
 
 end

--- a/lib/tasks/ow-logs.rake
+++ b/lib/tasks/ow-logs.rake
@@ -10,12 +10,12 @@ namespace :ow do
     name = stack_name(args[:to])
     stack = Momentum::OpsWorks.get_stack(ow, name)
     instance = Momentum::OpsWorks.get_online_instances(ow, stack_id: stack[:stack_id]).detect{|i| i[:hostname] == args[:instance] }
+    raise "Online instance #{args[:instance]} not found for #{name} stack!" unless instance
     endpoint = Momentum::OpsWorks.get_instance_endpoint(instance)
-    raise "Online instance #{args[:instance]} not found for #{name} stack!" unless endpoint
 
     $stderr.puts "Starting tail -f remotely... (use Ctrl-D to exit cleanly)"
     command = "'sudo su deploy -c \"tail -f #{args[:log_path]}\"'"
-    sh Momentum::OpsWorks.ssh_command_to(endpoint,command)
+    sh Momentum::OpsWorks.ssh_command_to(endpoint, command)
   end
 
 end

--- a/lib/tasks/ow-ssh.rake
+++ b/lib/tasks/ow-ssh.rake
@@ -1,0 +1,25 @@
+namespace :ow do
+
+  require 'momentum/opsworks'
+  require 'momentum/tasks'
+
+  desc "Starts SSH session on a remote OpsWorks instance, as specified by layer or instance name."
+  task :ssh, [:to, :layer_or_instance, :aws_id, :aws_secret] do |t, args|
+    require_credentials!(args)
+    ow = Momentum::OpsWorks.client(args[:aws_id], args[:aws_secret])
+    name = stack_name(args[:to])
+    stack = Momentum::OpsWorks.get_stack(ow, name)
+    layer = ow.describe_layers(stack_id: stack[:stack_id])[:layers].detect { |l| l[:shortname] == args[:layer_or_instance] }
+    instance = if layer
+      Momentum::OpsWorks.get_online_instances(ow, layer_id: layer[:layer_id]).sample
+    else
+      Momentum::OpsWorks.get_online_instances(ow, stack_id: stack[:stack_id]).detect { |i| i[:hostname] == args[:layer_or_instance] }
+    end
+    raise "No online instances matching #{args[:layer_or_instance].inspect} were found!" unless instance
+    endpoint = Momentum::OpsWorks.get_instance_endpoint(instance)
+
+    $stderr.puts "Starting SSH... (use Ctrl-D to exit cleanly)"
+    sh Momentum::OpsWorks.ssh_command_to(endpoint)
+  end
+
+end


### PR DESCRIPTION
I found myself referring to the OpsWorks dashboard often for connection details (which I'd then copy into an SSH command). This lets me instead launch an SSH session with just a layer or instance name:

```
bundle exec rake ow:ssh[staging,memcached]
# or...
bundle exec rake ow:ssh[production,worker3]
```
