### PR TITLE
Adds optional db migrating to deploy command

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,15 @@ Zip, upload, and propagate custom cookbooks to the given stack. Or, more concise
     # or just:
     bundle exec rake ow:cookbooks:update:staging
 
-### ow:deploy[to,aws_id,aws_secret]
+### ow:deploy[to,migrate_db,aws_id,aws_secret]
 
 Trigger an OpsWorks deploy to the given stack. By default, deploys app to all running instances of the _rails-app_ layer, or the list configured in `app_layers`. E.g.:
 
     bundle exec rake ow:deploy[staging]
     # or just:
     bundle exec rake ow:deploy:staging
+    # if you want to trigger database migrations at the same time, add the optional arg
+    bundle exec rake ow:deploy[staging,true]
 
 ### ow:logs[to,instance,log_path,aws_id,aws_secret]
 

--- a/lib/momentum/opsworks.rb
+++ b/lib/momentum/opsworks.rb
@@ -77,7 +77,7 @@ module Momentum::OpsWorks
       @ow = Momentum::OpsWorks.client(aws_id, aws_secret)
     end
 
-    def deploy!(stack_name, app_name = Momentum.config[:app_base_name])
+    def deploy!(stack_name, migrate_db = false, app_name = Momentum.config[:app_base_name])
       stack = Momentum::OpsWorks.get_stack(@ow, stack_name)
       app = Momentum::OpsWorks.get_app(@ow, stack, app_name)
       layers = Momentum::OpsWorks.get_layers(@ow, stack, Momentum.config[:app_layers])
@@ -86,7 +86,12 @@ module Momentum::OpsWorks
       @ow.create_deployment(
         stack_id: stack[:stack_id],
         app_id: app[:app_id],
-        command: { name: 'deploy' },
+        command: { 
+          name: 'deploy',
+          args: {
+            'migrate' => [migrate_db.to_s]
+          } 
+        },
         instance_ids: instance_ids
       )
     end

--- a/lib/tasks/ow-deploy.rake
+++ b/lib/tasks/ow-deploy.rake
@@ -10,11 +10,11 @@ namespace :ow do
   end
 
   desc "Deploy to the given OpsWorks stack."
-  task :deploy, [:to, :aws_id, :aws_secret] do |t, args|
+  task :deploy, [:to, :migrate_db, :aws_id, :aws_secret] do |t, args|
     require_credentials!(args)
     deployer = Momentum::OpsWorks::Deployer.new(args[:aws_id], args[:aws_secret])
     name = stack_name(args[:to])
-    deployment = deployer.deploy!(name)
+    deployment = deployer.deploy!(name, args[:migrate_db] || false)
     $stderr.puts "Triggered deployment #{deployment[:deployment_id]} to #{name}..."
     deployer.wait_for_success!(deployment)
   end


### PR DESCRIPTION
This is to somewhat replicate the OpsWorks toggle button to run migrations. By default, migrations do not run, you must deliberately specify that they be run.
