### PR TITLE
@joeyAghion => Improve error handling in ow:console.

### DIFF
--- a/lib/tasks/ow-console.rake
+++ b/lib/tasks/ow-console.rake
@@ -10,9 +10,11 @@ namespace :ow do
     name = stack_name(args[:to])
     stack = Momentum::OpsWorks.get_stack(ow, name)
     layer = ow.describe_layers(stack_id: stack[:stack_id])[:layers].detect { |l| l[:shortname] == Momentum.config[:rails_console_layer] }
+    raise "No '#{Momentum.config[:rails_console_layer]}' layer found for #{name} stack!" unless layer
     instance = Momentum::OpsWorks.get_online_instances(ow, layer_id: layer[:layer_id]).sample
+    raise "No '#{Momentum.config[:rails_console_layer]}' instances found for #{name} stack!" unless instance
     endpoint = Momentum::OpsWorks.get_instance_endpoint(instance)
-    raise "No online #{Momentum.config[:rails_console_layer]} instances found for #{name} stack!" unless endpoint
+    raise "No online '#{Momentum.config[:rails_console_layer]}' instances found for #{name} stack!" unless endpoint
 
     $stderr.puts "Starting remote console... (use Ctrl-D to exit cleanly)"
     command = "'sudo su deploy -c \"cd /srv/www/#{Momentum.config[:app_base_name]}/current && RAILS_ENV=#{args[:env] || args[:to]} bundle exec rails console\"'"


### PR DESCRIPTION
Otherwise this:

```
rake aborted!
undefined method `[]' for nil:NilClass
/Users/dblock/.rvm/gems/ruby-2.0.0-p353/gems/momentum-0.0.9/lib/momentum/opsworks.rb:21:in `get_instance_endpoint'
/Users/dblock/.rvm/gems/ruby-2.0.0-p353/gems/momentum-0.0.9/lib/tasks/ow-console.rake:14:in `block (2 levels) in <top (required)>'
/Users/dblock/.rvm/gems/ruby-2.0.0-p353/bin/ruby_executable_hooks:15:in `eval'
/Users/dblock/.rvm/gems/ruby-2.0.0-p353/bin/ruby_executable_hooks:15:in `<main>'
Tasks: TOP => ow:console
```
