### PR TITLE
Rake task to execute recipe on a layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,13 @@ SSH to an OpsWorks instance. If the `layer_or_instance` argument is a layer, an 
     # or...
     bundle exec rake ow:ssh[staging,rails-app1]
 
+### ow:execute_recipe[to,layer,recipe,aws_id,aws_secret]
+
+Execute a Chec recipe on the given layer in the given stack. By default, will execute recipes on all running instances of the _rails-app_ layer, or the list configured in `app_layers`. E.g.:
+
+    bundle exec rake ow:execute_recipe[staging,rails-app,restart_unicorns]
+    # Assuming 'restart_unicorns' is a valid Chef recipe.
+
 
 ## Configuration:
 

--- a/lib/tasks/ow-execute_recipe.rake
+++ b/lib/tasks/ow-execute_recipe.rake
@@ -1,0 +1,21 @@
+namespace :ow do
+
+  require 'momentum/tasks'
+
+  namespace :execute_recipe do
+    %w{staging production}.each do |env|
+      desc "Execute recipe on #{Momentum.config[:app_base_name]} in the #{stack_name(env)} OpsWorks stack."
+      task(env.to_sym) { Rake::Task['ow:execute_recipe'].invoke(env) }
+    end
+  end
+
+  desc "Execute a recipe on the given OpsWorks stack."
+  task :execute_recipe, [:to, :layer, :recipe, :aws_id, :aws_secret] do |t, args|
+    require_credentials!(args)
+    deployer = Momentum::OpsWorks::Deployer.new(args[:aws_id], args[:aws_secret])
+    name = stack_name(args[:to])
+    recipe_runner = deployer.execute_recipe!(name, args[:layer], args[:recipe])
+    $stderr.puts "Running #{recipe} #{deployment[:deployment_id]} to #{name}..."
+    deployer.wait_for_success!(recipe_runner)
+  end
+end


### PR DESCRIPTION
This adds a rake task to let a user execute a recipe on OpsWorks. It can be useful to allow devs to run a rake task in order to execute a recipe (rather than logging in and using the OpsWorks management UI to run a recipe), and thus can also be easily scheduled using Jenkins, or your favorite CI.