### PR TITLE
Fall back to default when layer argument to execute_recipe task is empty

### DIFF
--- a/lib/tasks/ow-execute_recipe.rake
+++ b/lib/tasks/ow-execute_recipe.rake
@@ -15,8 +15,9 @@ namespace :ow do
     deployer = Momentum::OpsWorks::Deployer.new(args[:aws_id], args[:aws_secret])
     name = stack_name(args[:to])
     recipe = args[:recipe]
-    recipe_runner = deployer.execute_recipe!(name, args[:layer], recipe)
-    $stderr.puts "Running #{recipe} #{recipe_runner[:deployment_id]} to #{name}..."
+    layer = args[:layer] if args[:layer] && !args[:layer].empty?
+    recipe_runner = deployer.execute_recipe!(name, layer, recipe)
+    $stderr.puts "Applying #{recipe} #{recipe_runner[:deployment_id]} to #{[name, layer].compact.join(', ')}..."
     deployer.wait_for_success!(recipe_runner)
   end
 end


### PR DESCRIPTION
The `ow:execute_recipe` task offers a default `layer` corresponding to the configured `app_layers`. However, I think it's impossible to actually use this default since the next argument is required. This modifies the task to use the default if the argument is empty, allowing the task to be invoked like:

    rake ow:execute_recipe[staging,,some_recipe]

