### PR TITLE
[Console] Force UTF-8 encoding for STDOUT.

### DIFF
--- a/lib/tasks/ow-console.rake
+++ b/lib/tasks/ow-console.rake
@@ -17,7 +17,7 @@ namespace :ow do
     raise "No online '#{Momentum.config[:rails_console_layer]}' instances found for #{name} stack!" unless endpoint
 
     $stderr.puts "Starting remote console... (use Ctrl-D to exit cleanly)"
-    command = "'sudo su deploy -c \"cd /srv/www/#{Momentum.config[:app_base_name]}/current && RAILS_ENV=#{args[:env] || args[:to]} bundle exec rails console\"'"
+    command = "'sudo su deploy -c \"cd /srv/www/#{Momentum.config[:app_base_name]}/current && RAILS_ENV=#{args[:env] || args[:to]} RUBYOPT=-EUTF-8 bundle exec rails console\"'"
     sh Momentum::OpsWorks.ssh_command_to(endpoint,command)
   end
 


### PR DESCRIPTION
I’ve been unable to determine why STDOUT in our console sessions get an external encoding of US-ASCII, but this at least ensures it’s forced to UTF-8.