### PR TITLE
updates for generic Chef12 stacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,21 +69,19 @@ Package, upload, and propagate custom cookbooks to the given stack. Or, more con
     # or just:
     bundle exec rake ow:cookbooks:update:staging
 
-### ow:deploy[to,migrate_db,aws_id,aws_secret]
+### ow:deploy[to,aws_id,aws_secret]
 
 Trigger an OpsWorks deploy to the given stack. By default, deploys app to all running instances of the _rails-app_ layer, or the list configured in `app_layers`. E.g.:
 
     bundle exec rake ow:deploy[staging]
     # or just:
     bundle exec rake ow:deploy:staging
-    # if you want to trigger database migrations at the same time, add the additional flag
-    bundle exec rake ow:deploy:migrations[staging]
 
 ### ow:logs[to,instance,log_path,aws_id,aws_secret]
 
 Execute a tail -f (follow) command against a remote log path on the given remote OpsWorks instance and stack. The path may include wildcards. E.g.:
 
-    bundle exec rake ow:logs[staging,rails-app1,/srv/www/myapp/shared/log/staging.log]
+    bundle exec rake ow:logs[staging,rails-app1,/home/deploy/myapp/shared/log/staging.log]
 
 ### ow:ssh[to,layer_or_instance,aws_id,aws_secret]
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Add the given stack's custom configuration values to the current task's ENV. Can
 
 ### ow:console[to,env,aws_id,aws_secret]
 
-Start a rails console on the given remote OpsWorks stack. Chooses an instance of the _rails-app_ layer by default, or the configured `rails_console_layer` if provided. E.g.:
+Start a rails console on the given remote OpsWorks stack. Chooses an instance of the _rails_ layer by default, or the configured `rails_console_layer` if provided. E.g.:
 
     bundle exec rake ow:console[production]
 
@@ -71,7 +71,7 @@ Package, upload, and propagate custom cookbooks to the given stack. Or, more con
 
 ### ow:deploy[to,aws_id,aws_secret]
 
-Trigger an OpsWorks deploy to the given stack. By default, deploys app to all running instances of the _rails-app_ layer, or the list configured in `app_layers`. E.g.:
+Trigger an OpsWorks deploy to the given stack. By default, deploys app to all running instances of the _rails_ layer, or the list configured in `app_layers`. E.g.:
 
     bundle exec rake ow:deploy[staging]
     # or just:
@@ -81,7 +81,7 @@ Trigger an OpsWorks deploy to the given stack. By default, deploys app to all ru
 
 Execute a tail -f (follow) command against a remote log path on the given remote OpsWorks instance and stack. The path may include wildcards. E.g.:
 
-    bundle exec rake ow:logs[staging,rails-app1,/home/deploy/myapp/shared/log/staging.log]
+    bundle exec rake ow:logs[staging,rails1,/home/deploy/myapp/shared/log/staging.log]
 
 ### ow:ssh[to,layer_or_instance,aws_id,aws_secret]
 
@@ -89,23 +89,23 @@ SSH to an OpsWorks instance. If the `layer_or_instance` argument is a layer, an 
 
     bundle exec rake ow:ssh[staging,memcached]
     # or...
-    bundle exec rake ow:ssh[staging,rails-app1]
+    bundle exec rake ow:ssh[staging,rails1]
 
 ### ow:execute_recipe[to,layer,recipe,aws_id,aws_secret]
 
-Execute a Chef recipe on the given layer in the given stack. By default, will execute recipes on all running instances of the _rails-app_ layer, or the list configured in `app_layers`. E.g.:
+Execute a Chef recipe on the given layer in the given stack. By default, will execute recipes on all running instances of the _rails_ layer, or the list configured in `app_layers`. E.g.:
 
-    bundle exec rake ow:execute_recipe[staging,rails-app,restart_unicorns]
+    bundle exec rake ow:execute_recipe[staging,rails,restart_unicorns]
     # Assuming 'restart_unicorns' is a valid Chef recipe.
 
 
 ## Configuration:
 
 * **app_base_name** - Your app's name. Stacks are assumed to be named like _appbasename-env_ (e.g., _gravity-staging_ or _reflection-joey_).
-* **app_layers** - Array of OpsWorks layer names to which this rails app should be deployed. Default: `['rails-app']`
+* **app_layers** - Array of OpsWorks layer names to which this rails app should be deployed. Default: `['rails']`
 * **cookbooks_install_path** - Local path where berkshelf will install cookbooks. Default: _tmp/cookbooks.tgz_
 * **custom_cookbooks_bucket** - Bucket to which custom cookbooks are uploaded. Default: _artsy-cookbooks_
-* **rails_console_layer** - The OpsWorks layer used for SSH-ing and starting a rails console. Default: _rails-app_
+* **rails_console_layer** - The OpsWorks layer used for SSH-ing and starting a rails console. Default: _rails_
 
 
 ## To Do

--- a/lib/momentum.rb
+++ b/lib/momentum.rb
@@ -9,7 +9,8 @@ module Momentum
     custom_cookbooks_bucket: 'artsy-cookbooks',
     rails_console_layer: 'rails-app',
     app_layers: ['rails-app'],
-    logs_root: '/var/log/apache2/'
+    logs_root: '/var/log/nginx/',
+    deploy_root: '/home/deploy',
   }
 
   def self.config

--- a/lib/momentum.rb
+++ b/lib/momentum.rb
@@ -7,10 +7,11 @@ module Momentum
     # app_base_name: ...,  # required
     cookbooks_install_path: 'tmp/cookbooks.tgz',
     custom_cookbooks_bucket: 'artsy-cookbooks',
-    rails_console_layer: 'rails-app',
-    app_layers: ['rails-app'],
+    rails_console_layer: 'rails',
+    app_layers: ['rails'],
     logs_root: '/var/log/nginx/',
     deploy_root: '/home/deploy',
+    remote_bundle_path: '/usr/local/bin/bundle'
   }
 
   def self.config

--- a/lib/momentum.rb
+++ b/lib/momentum.rb
@@ -11,7 +11,7 @@ module Momentum
     app_layers: ['rails'],
     logs_root: '/var/log/nginx/',
     deploy_root: '/home/deploy',
-    remote_bundle_path: '/usr/local/bin/bundle'
+    append_path: '/usr/local/bin'
   }
 
   def self.config

--- a/lib/tasks/ow-console.rake
+++ b/lib/tasks/ow-console.rake
@@ -17,7 +17,7 @@ namespace :ow do
     raise "No online '#{Momentum.config[:rails_console_layer]}' instances found for #{name} stack!" unless endpoint
 
     $stderr.puts "Starting remote console... (use Ctrl-D to exit cleanly)"
-    command = "'sudo su deploy -c \"cd #{Momentum.config[:deploy_root]}/#{Momentum.config[:app_base_name]}/current && RAILS_ENV=#{args[:env] || args[:to]} RUBYOPT=-EUTF-8 bundle exec rails console\"'"
+    command = "'sudo su deploy -c \"cd #{Momentum.config[:deploy_root]}/#{Momentum.config[:app_base_name]}/current && RAILS_ENV=#{args[:env] || args[:to]} RUBYOPT=-EUTF-8 #{Momentum.config[:remote_bundle_path]} exec rails console\"'"
     sh Momentum::OpsWorks.ssh_command_to(endpoint,command)
   end
 

--- a/lib/tasks/ow-console.rake
+++ b/lib/tasks/ow-console.rake
@@ -17,7 +17,7 @@ namespace :ow do
     raise "No online '#{Momentum.config[:rails_console_layer]}' instances found for #{name} stack!" unless endpoint
 
     $stderr.puts "Starting remote console... (use Ctrl-D to exit cleanly)"
-    command = "'sudo su deploy -c \"cd #{Momentum.config[:deploy_root]}/#{Momentum.config[:app_base_name]}/current && RAILS_ENV=#{args[:env] || args[:to]} RUBYOPT=-EUTF-8 #{Momentum.config[:remote_bundle_path]} exec rails console\"'"
+    command = "'sudo su deploy -c \"cd #{Momentum.config[:deploy_root]}/#{Momentum.config[:app_base_name]}/current && PATH=PATH:#{Momentum.config[:append_path]} RAILS_ENV=#{args[:env] || args[:to]} RUBYOPT=-EUTF-8 bundle exec rails console\"'"
     sh Momentum::OpsWorks.ssh_command_to(endpoint,command)
   end
 

--- a/lib/tasks/ow-console.rake
+++ b/lib/tasks/ow-console.rake
@@ -17,7 +17,7 @@ namespace :ow do
     raise "No online '#{Momentum.config[:rails_console_layer]}' instances found for #{name} stack!" unless endpoint
 
     $stderr.puts "Starting remote console... (use Ctrl-D to exit cleanly)"
-    command = "'sudo su deploy -c \"cd /srv/www/#{Momentum.config[:app_base_name]}/current && RAILS_ENV=#{args[:env] || args[:to]} RUBYOPT=-EUTF-8 bundle exec rails console\"'"
+    command = "'sudo su deploy -c \"cd #{Momentum.config[:deploy_root]}/#{Momentum.config[:app_base_name]}/current && RAILS_ENV=#{args[:env] || args[:to]} RUBYOPT=-EUTF-8 bundle exec rails console\"'"
     sh Momentum::OpsWorks.ssh_command_to(endpoint,command)
   end
 

--- a/lib/tasks/ow-deploy.rake
+++ b/lib/tasks/ow-deploy.rake
@@ -18,16 +18,4 @@ namespace :ow do
     $stderr.puts "Triggered deployment #{deployment[:deployment_id]} to #{name}..."
     deployer.wait_for_success!(deployment)
   end
-
-  namespace :deploy do
-    desc "Deploy to the given OpsWorks stack and tigger database migrations."
-    task :migrations, [:to, :aws_id, :aws_secret] do |t, args|
-      require_credentials!(args)
-      deployer = Momentum::OpsWorks::Deployer.new(args[:aws_id], args[:aws_secret])
-      name = stack_name(args[:to])
-      deployment = deployer.deploy!(name, true)
-      $stderr.puts "Triggered deployment #{deployment[:deployment_id]} and database migrations to #{name}..."
-      deployer.wait_for_success!(deployment)
-    end
-  end
 end


### PR DESCRIPTION
updates for generic Chef12 stacks - drop migrate arg to deploy command, change logs_root and add deploy_root in config, drop Chef11 layer dependencies
