### PR TITLE
[console] Pass rake env variables on to remote process.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.2.0 ()
+------
+
+* Allow user to specify remote env variables for their console session ([23](https://github.com/artsy/momentum/pull/23))
+
 0.1.0 (2016-01-18)
 ------
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Add the given stack's custom configuration values to the current task's ENV. Can
 
     bundle exec rake ow:config:from_env[production] some:migration
 
-### ow:console[to,env,aws_id,aws_secret]
+### ow:console[to,env,aws_id,aws_secret] [env ...]
 
 Start a rails console on the given remote OpsWorks stack. Chooses an instance of the _rails_ layer by default, or the configured `rails_console_layer` if provided. E.g.:
 
@@ -60,6 +60,10 @@ Start a rails console on the given remote OpsWorks stack. Chooses an instance of
 For stacks with labels not matching the Rails environment (e.g., _reflection-joey_), provide a 2nd argument with the desired environment:
 
     bundle exec rake ow:console[joey,staging]
+
+To set environment variables for the remote process, specify them _after_ the task name like you normally would with rake tasks:
+
+    bundle exec rake ow:console[production] SOME_ENV_VARIABLE=set-remotely
 
 ### ow:cookbooks:update[to,aws_id,aws_secret]
 

--- a/lib/tasks/ow-console.rake
+++ b/lib/tasks/ow-console.rake
@@ -15,10 +15,14 @@ namespace :ow do
     raise "No '#{Momentum.config[:rails_console_layer]}' instances found for #{name} stack!" unless instance
     endpoint = Momentum::OpsWorks.get_instance_endpoint(instance)
     raise "No online '#{Momentum.config[:rails_console_layer]}' instances found for #{name} stack!" unless endpoint
+
     env = ARGV.grep(/^(\w+)=(.*)$/m)
+    env << "PATH=$PATH:#{Momentum.config[:append_path]}"
+    env << "RAILS_ENV=#{args[:env] || args[:to]}"
+    env << "RUBYOPT=-EUTF-8"
 
     $stderr.puts "Starting remote console... (use Ctrl-D to exit cleanly)"
-    command = "'sudo su deploy -c \"cd #{Momentum.config[:deploy_root]}/#{Momentum.config[:app_base_name]}/current && env #{env.join(" ")} PATH=$PATH:#{Momentum.config[:append_path]} RAILS_ENV=#{args[:env] || args[:to]} RUBYOPT=-EUTF-8 bundle exec rails console\"'"
+    command = "'sudo su deploy -c \"cd #{Momentum.config[:deploy_root]}/#{Momentum.config[:app_base_name]}/current && env #{env.join(" ")} bundle exec rails console\"'"
     sh Momentum::OpsWorks.ssh_command_to(endpoint,command)
   end
 

--- a/lib/tasks/ow-console.rake
+++ b/lib/tasks/ow-console.rake
@@ -15,9 +15,10 @@ namespace :ow do
     raise "No '#{Momentum.config[:rails_console_layer]}' instances found for #{name} stack!" unless instance
     endpoint = Momentum::OpsWorks.get_instance_endpoint(instance)
     raise "No online '#{Momentum.config[:rails_console_layer]}' instances found for #{name} stack!" unless endpoint
+    env = ARGV.grep(/^(\w+)=(.*)$/m)
 
     $stderr.puts "Starting remote console... (use Ctrl-D to exit cleanly)"
-    command = "'sudo su deploy -c \"cd #{Momentum.config[:deploy_root]}/#{Momentum.config[:app_base_name]}/current && PATH=$PATH:#{Momentum.config[:append_path]} RAILS_ENV=#{args[:env] || args[:to]} RUBYOPT=-EUTF-8 bundle exec rails console\"'"
+    command = "'sudo su deploy -c \"cd #{Momentum.config[:deploy_root]}/#{Momentum.config[:app_base_name]}/current && env #{env.join(" ")} PATH=$PATH:#{Momentum.config[:append_path]} RAILS_ENV=#{args[:env] || args[:to]} RUBYOPT=-EUTF-8 bundle exec rails console\"'"
     sh Momentum::OpsWorks.ssh_command_to(endpoint,command)
   end
 


### PR DESCRIPTION
These are env variables defined as part of the arguments given to `rake`

For instance:

    rake ow:console[production] MONGODB_SOCKET_TIMEOUT=30

…would invoke the remote process with:

    env MONGODB_SOCKET_TIMEOUT=30 bundle exec rails console

----

:warning: This patch is made against the 0.0.13 release, because the current 0.1.0 release has a berkshelf version requirement that’s incompatible with Gravity’s current bundle ([berkshelf v4.3.5](https://github.com/berkshelf/berkshelf/blob/v4.3.5/berkshelf.gemspec) has a hard `celluloid = 0.16.0` requirement). Thus this won’t apply to master.

Is it possible to upgrade the berkshelf dependency? Newer versions don’t have this dependency any longer. Alternatively we could make a 0.0.14 release so that this patch can at least be pulled into Gravity.