### PR TITLE
Backport remote env feature to 0.0.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.0.14 ()
+------
+
+* Allow user to specify remote env variables for their console session ([24](https://github.com/artsy/momentum/pull/24))
+
 0.0.13 (2016-01-18)
 ------
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Add the given stack's custom configuration values to the current task's ENV. Can
 
     bundle exec rake ow:config:from_env[production] some:migration
 
-### ow:console[to,env,aws_id,aws_secret]
+### ow:console[to,env,aws_id,aws_secret] [env ...]
 
 Start a rails console on the given remote OpsWorks stack. Chooses an instance of the _rails-app_ layer by default, or the configured `rails_console_layer` if provided. E.g.:
 
@@ -60,6 +60,10 @@ Start a rails console on the given remote OpsWorks stack. Chooses an instance of
 For stacks with labels not matching the Rails environment (e.g., _reflection-joey_), provide a 2nd argument with the desired environment:
 
     bundle exec rake ow:console[joey,staging]
+
+To set environment variables for the remote process, specify them _after_ the task name like you normally would with rake tasks:
+
+    bundle exec rake ow:console[production] SOME_ENV_VARIABLE=set-remotely
 
 ### ow:cookbooks:update[to,aws_id,aws_secret]
 

--- a/lib/tasks/ow-console.rake
+++ b/lib/tasks/ow-console.rake
@@ -15,9 +15,10 @@ namespace :ow do
     raise "No '#{Momentum.config[:rails_console_layer]}' instances found for #{name} stack!" unless instance
     endpoint = Momentum::OpsWorks.get_instance_endpoint(instance)
     raise "No online '#{Momentum.config[:rails_console_layer]}' instances found for #{name} stack!" unless endpoint
+    env = ARGV.grep(/^(\w+)=(.*)$/m)
 
     $stderr.puts "Starting remote console... (use Ctrl-D to exit cleanly)"
-    command = "'sudo su deploy -c \"cd /srv/www/#{Momentum.config[:app_base_name]}/current && RAILS_ENV=#{args[:env] || args[:to]} RUBYOPT=-EUTF-8 bundle exec rails console\"'"
+    command = "'sudo su deploy -c \"cd /srv/www/#{Momentum.config[:app_base_name]}/current && env #{env.join(" ")} RAILS_ENV=#{args[:env] || args[:to]} RUBYOPT=-EUTF-8 bundle exec rails console\"'"
     sh Momentum::OpsWorks.ssh_command_to(endpoint,command)
   end
 

--- a/lib/tasks/ow-console.rake
+++ b/lib/tasks/ow-console.rake
@@ -15,10 +15,13 @@ namespace :ow do
     raise "No '#{Momentum.config[:rails_console_layer]}' instances found for #{name} stack!" unless instance
     endpoint = Momentum::OpsWorks.get_instance_endpoint(instance)
     raise "No online '#{Momentum.config[:rails_console_layer]}' instances found for #{name} stack!" unless endpoint
+
     env = ARGV.grep(/^(\w+)=(.*)$/m)
+    env << "RAILS_ENV=#{args[:env] || args[:to]}"
+    env << "RUBYOPT=-EUTF-8"
 
     $stderr.puts "Starting remote console... (use Ctrl-D to exit cleanly)"
-    command = "'sudo su deploy -c \"cd /srv/www/#{Momentum.config[:app_base_name]}/current && env #{env.join(" ")} RAILS_ENV=#{args[:env] || args[:to]} RUBYOPT=-EUTF-8 bundle exec rails console\"'"
+    command = "'sudo su deploy -c \"cd /srv/www/#{Momentum.config[:app_base_name]}/current && env #{env.join(" ")} bundle exec rails console\"'"
     sh Momentum::OpsWorks.ssh_command_to(endpoint,command)
   end
 


### PR DESCRIPTION
This is the same feature as https://github.com/artsy/momentum/pull/23, except applied to 0.0.13 (without berkshelf) so that it can be released as 0.0.14 for Gravity.