### PR TITLE
Allow berkshelf version to float past 4.3.*

### DIFF
--- a/momentum.gemspec
+++ b/momentum.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "aws-sdk", "~> 1.30"
-  spec.add_dependency "berkshelf", "~> 4.3.5"
+  spec.add_dependency "berkshelf", ">= 4.3"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
From what I can tell, the `berkshelf` dependency stems from a single use of the `berks package ...` command. This continues to be available in more recent `berkshelf` versions. Upgrading would help us migrate from older versions that specify conflicting `celluloid` dependencies. A quick test confirmed that the `rake ow:cookbooks:berks_package` task still works.